### PR TITLE
Fix buffer overflow in update

### DIFF
--- a/generator-controller.ino
+++ b/generator-controller.ino
@@ -289,39 +289,39 @@ int update() {
   }
 
 
-  memcpy(tempchar, &response[1], 5);
+  memcpy(tempchar, response+1, 5);
   tempchar[5] = '\0';
   genvoltage = strtof(tempchar, NULL);
 
-  memcpy(tempchar, &response[12], 16);
+  memcpy(tempchar, response+12, 5);
   tempchar[5] = '\0';
   acvoltage = strtof(tempchar, NULL);
 
-  memcpy(tempchar, &response[18], 21);
+  memcpy(tempchar, response+18, 4);
   tempchar[4] = '\0';
   acfrequency = strtof(tempchar, NULL);
 
-  memcpy(tempchar, &response[28], 31);
+  memcpy(tempchar, response+28, 4);
   tempchar[4] = '\0';
   acpower = strtol(tempchar, NULL, 10);
 
-  memcpy(tempchar, &response[41], 45);
+  memcpy(tempchar, response+41, 5);
   tempchar[5] = '\0';
   battvoltage = strtof(tempchar, NULL);
 
-  memcpy(tempchar, &response[47], 49);
+  memcpy(tempchar, response+47, 3);
   tempchar[3] = '\0';
   battchrgcurrent = strtol(tempchar, NULL, 10);
 
-  memcpy(tempchar, &response[51], 53);
+  memcpy(tempchar, response+51, 3);
   tempchar[3] = '\0';
   battcapacity = strtol(tempchar, NULL, 10);
 
-  memcpy(tempchar, &response[80], 84);
+  memcpy(tempchar, response+80, 5);
   tempchar[5] = '\0';
   battdischrgcurrent = strtol(tempchar, NULL, 10);
 
-  memcpy(tempchar, &response[99], 104);
+  memcpy(tempchar, response+99, 5);
   tempchar[5] = '\0';
   pvpower1 = strtol(tempchar, NULL, 10);
 
@@ -330,7 +330,7 @@ int update() {
     return 0;
   }
 
-  memcpy(tempchar, &response[12], 16);
+  memcpy(tempchar, response+12, 5);
   tempchar[5] = '\0';
   pvpower2 = strtol(tempchar, NULL, 10);
 


### PR DESCRIPTION
Fixes an oversight on the `memcpy` section in `update`, basically `memcpy` was used like: `memcpy(source, source-start, source-end)`, rather than `memcpy(target, source, bytes-to-copy)`. See [the cppreference for further details](https://cplusplus.com/reference/cstring/memcpy).
Under normal circumstances this would cause segmentation faults under standard kernels and/or the overwrite of useful memory, leading to bugs where certain variables change value unexpectedly (undefined behavior).
Luckily, since `response` was defined right after `tempchar` the bad `memcpy` usage causes the initial bytes of `response` to get overwritten, but the affected bytes are coincidentally already used and processed so no issues arise. BUT, this is still a huge problem because in the circumstance where a new variable is defined between `tempchar` and `response` or the order of those is changed, disaster will strike.

As a bottom note id like to point out another possible problem [here](https://github.com/hapsti/generator-controller/blob/9854bf2ac68c4be9344528aae5fcac4e6d23ce79/generator-controller.ino#L394), a reference to `response` (which is a `char*`) is obtained an then casted to `unsigned char*`, which leads to the following cast: `char** -> unsigned char*`. Though i am not sure why this doesn't cause issues so i might be wrong here.

Great video btw!